### PR TITLE
changing module from package to dnf for apache install

### DIFF
--- a/apache.yml
+++ b/apache.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Ensure the httpd software is installed
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: httpd
         state: present
     - name: Copy index.html page to html root


### PR DESCRIPTION
The package module will anyways just run the dnf module, so let's run it immediately instead.