### PR TITLE
Switch from package to dnf in apache.yml

### DIFF
--- a/apache.yml
+++ b/apache.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Ensure the httpd software is installed
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: httpd
         state: present
     - name: Copy index.html page to html root


### PR DESCRIPTION
The package module calls the dnf module, so why not call it directly as we know what to use.